### PR TITLE
Mesos 0.28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ ansible.cfg
 frameworks/marathon/marathon-*
 frameworks/spark/spark-*
 frameworks/spark/derby.log
+frameworks/spark/metastore_db
 frameworks/jenkins/mesos-plugin

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ see Vagrantfile for precise version.
 * the centos base image above
 * Ansible on your host machine
 * Virtualbox on host machine (box has 4.3.28 extensions)
-* Vagrant 1.6.4 or better
+* Vagrant 1.8.x or better (for linked_clones)
 * a Vagrant plugin (see below)
 
 ## assumptions

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Mesos cluster
 CentOS 7 based Mesos cluster. Intended to be a clean baseline
 for framework testing.
 
-Currently 0.22.1 with docker bridged networking support
-(see examples/marathon/ for details on using it).
+Currently 0.28.1 with docker support and cgroups isolation
+(see roles/mesos/{slave,master}/defaults for various tunings).
 
 See frameworks/ for some ways to run frameworks against this stack.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 1.8.0"
+
 ## if you change these, change vagrant/hosts too
 #
 # would _dearly_ love to make this less clunkable,
@@ -36,6 +38,7 @@ Vagrant.configure("2") do |config|
 
       c.vm.provider("virtualbox") do |vb|
         vb.memory = host[:ram]
+        vb.linked_clone = true
       end
 
       # turn off shared folder

--- a/frameworks/jenkins/Dockerfile.mvn3
+++ b/frameworks/jenkins/Dockerfile.mvn3
@@ -1,0 +1,10 @@
+FROM rasputnik/openjdk8:v1
+
+RUN apk add git
+
+RUN curl http://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar zxf -
+RUN mv apache-maven-3.3.9 /usr/lib/mvn
+
+ENV M2_HOME=/usr/lib/mvn
+ENV M2=$M2_HOME/bin
+ENV PATH $PATH:$M2

--- a/frameworks/jenkins/Dockerfile.openjdk8
+++ b/frameworks/jenkins/Dockerfile.openjdk8
@@ -1,0 +1,6 @@
+FROM alpine
+
+RUN apk update
+RUN apk add openjdk8
+ENV JAVA_HOME /usr/lib/jvm/default-jvm
+ENV PATH $JAVA_HOME/bin:$PATH

--- a/frameworks/jenkins/README.md
+++ b/frameworks/jenkins/README.md
@@ -1,4 +1,3 @@
-
 This readme assumes you already have the Vagrant mesos stack VMs running on your Mac.
 
 # install Jenkins on your Mac
@@ -29,27 +28,12 @@ install the plugin and bounce jenkins.
 
 # prep a docker image
 
-The slaves have no maven/git/jdk, but since our builds are running in a docker
-container that's not a problem. We'll just craft an image with our requirements in it.
+The slaves have no JDK, git or maven installation.
 
-In production, you'd be using a Docker registry and have Mesos pull images down
-at runtime when Jenkins requests them. For simplicity, let's build the image on each slave.
+Since our builds are running in a docker container that's not a problem.
 
-This Dockerfile will be enough for us:
-
-    #------------------8<------------------
-    FROM mesosphere/spark:1.4.1-hdfs
-    
-    RUN apt-get update
-    RUN apt-get install -y git maven
-    
-    #------------------8<------------------
-
-_(NB: the 'mesosphere/spark1.4.1-hdfs' image is pretty big, but I already have it from the Spark example)_
-
-Copy this Dockerfile to each slave, then build with:
-
-    sudo docker build -t janky .
+We'll just craft an image with our requirements in it. To save time I've 
+put one up as 'rasputnik/mvn3:v1' _(Dockerfiles are in this folder_).
 
 # set up mesos plugin
 
@@ -57,7 +41,7 @@ go to http://localhost:8080/jenkins/configure , and at the
 bottom you'll see 'add a new cloud' dropdown. choose 'Mesos Cloud'.
 
     Mesos native library path :
-        /usr/local/Cellar/mesos/0.22.1/lib/libmesos.dylib
+        /usr/local/Cellar/mesos/0.28.0/lib/libmesos.dylib
         ( C++ shared lib for jenkins to talk to mesos)
     Mesos master :
         zk://master1:2181/mesos 
@@ -106,7 +90,7 @@ particular slave task). The important part is 'Docker Image' which tells Jenkins
     Use Docker Containerizer:
         tick
     Docker Image:
-        janky
+        'rasputnik/mvn3:v1'
     Networking:
         host
 
@@ -178,6 +162,3 @@ cloud -> mesos cloud -> 'advanced' -> 'add slave info'
 
 set whatever options you like, save it with a different label
 and you can assign builds to it as before. 
-
-
-

--- a/frameworks/jenkins/README.md
+++ b/frameworks/jenkins/README.md
@@ -12,7 +12,9 @@ This readme assumes you already have the Vagrant mesos stack VMs running on your
     mvn hpi:run
 
 Once it downloads the internet, it'll
-spin up a jenkins on http://localhost:8080/jenkins/
+spin up a jenkins locally
+
+    open http://localhost:8080/jenkins/
 
 # add git plugin to master
 
@@ -37,8 +39,9 @@ put one up as 'rasputnik/mvn3:v1' _(Dockerfiles are in this folder_).
 
 # set up mesos plugin
 
-go to http://localhost:8080/jenkins/configure , and at the 
-bottom you'll see 'add a new cloud' dropdown. choose 'Mesos Cloud'.
+    open http://localhost:8080/jenkins/configure
+
+at the bottom you'll see 'add a new cloud' dropdown. choose 'Mesos Cloud'.
 
     Mesos native library path :
         /usr/local/Cellar/mesos/0.28.0/lib/libmesos.dylib
@@ -48,11 +51,12 @@ bottom you'll see 'add a new cloud' dropdown. choose 'Mesos Cloud'.
         ( find master via zookeeper )
     Description :
         test mesos cluster
-    Framework principal :
-        blank it out
+    Slave username :
+        root
+        ( what user to run the mesos tasks as )
     Jenkins URL:
         http://10.0.0.1:8080/jenkins
-        (a URL the slave can reach on its subnet):
+        (URL should be reachable from the slaves i.e. in the host-only subnets)
 
 save/apply now (the jenkins ui is pretty hideous and renders
 badly, save as you go). you should see a zookeeper connection
@@ -62,8 +66,12 @@ Click 'Advanced' (directly under the Jenkins URL box):
 
     Checkpointing:
         yes
+    (mesos frameworks should always checkpoint)
     On-demand framework registration
         yes
+    (this only connects to mesos when there's work to do. 
+     It means you won't see jenkins in the mesos ui when it's not building,
+     but makes it play nicer with other frameworks if its running 'hungry' jobs)
 
 That's it for the actual mesos connectivity settings.
 
@@ -110,7 +118,7 @@ call it 'game-of-life', 'freestyle software project' -> ok.
     Source Code Management:
        git
     Repository URL:
-        https://github.com/rasputnik/game-of-life.git
+        https://github.com/{your-github}/game-of-life.git
         (don't use 'git://' urls, proxies tend to not like them)
 
 

--- a/frameworks/marathon/README.md
+++ b/frameworks/marathon/README.md
@@ -9,7 +9,7 @@ saves cluttering the stack with frameworks.
 
 get your tarball:
 
-    export M_VER=0.7.5
+    export M_VER=1.1.0
 
     curl -s http://downloads.mesosphere.io/marathon/v${M_VER}/marathon-${M_VER}.tgz | tar zxv
 

--- a/frameworks/spark/Dockerfile.spark-1.6.1
+++ b/frameworks/spark/Dockerfile.spark-1.6.1
@@ -1,0 +1,6 @@
+FROM rasputnik/openjdk8:v1
+
+RUN apk add curl bash
+RUN curl http://d3kbcqa49mib13.cloudfront.net/spark-1.6.1-bin-hadoop2.6.tgz | tar zxf -
+
+ENV SPARK_HOME /spark-1.6.1-bin-hadoop2.6

--- a/frameworks/spark/sparkconf/spark-defaults.conf
+++ b/frameworks/spark/sparkconf/spark-defaults.conf
@@ -1,17 +1,24 @@
 # Default system properties included when running spark-submit.
 
-# one mesos task on each slave, jobs run in there
-spark.mesos.coarse true
+spark.app.name "Docker Test"
 
 # use a mesos cluster, find master from zk
 spark.master mesos://zk://master1:2181/mesos
 
-# memory used by driver == the spark program/shell you're running
-spark.driver.memory 2g
-# docker images with spark and a jvm
-spark.mesos.executor.docker.image mesosphere/spark:1.4.1-hdfs
+# one mesos task per slave, multiple executors in there
+spark.mesos.coarse true
 
-# where is spark in the image? (found it via a 'docker run' to check)
-# (without this the executor will use your shells values,
-# which probably don't exist on the docker image)
-spark.mesos.executor.home /opt/spark/dist
+# memory used by driver == the spark program/shell you're running
+spark.driver.memory 1g
+
+# snappy needs a C library I don't have in my image
+spark.io.compression.codec lzf
+
+# docker images with spark and a jvm
+spark.mesos.executor.docker.image rasputnik/spark-1.6.1:v1
+# SPARK_HOME in the image
+spark.mesos.executor.home /spark-1.6.1-bin-hadoop2.6
+
+# how many cores per executor?
+spark.mesos.mesosExecutor.cores 0.2
+spark.executor.memory 512M

--- a/frameworks/spark/sparkconf/spark-env.sh
+++ b/frameworks/spark/sparkconf/spark-env.sh
@@ -4,6 +4,4 @@
 # Copy it as spark-env.sh and edit that to configure Spark for your site.
 
 # mesos
-# set MESOS_NATIVE_JAVA_LIBRARY for the spark shell
-# - it's already set (as an env. var) in our docker image.
-export MESOS_NATIVE_JAVA_LIBRARY=/usr/local/Cellar/mesos/0.22.1/lib/libmesos.dylib
+export MESOS_NATIVE_JAVA_LIBRARY=/usr/local/Cellar/mesos/0.28.0/lib/libmesos.dylib

--- a/vagrant/hosts
+++ b/vagrant/hosts
@@ -15,7 +15,7 @@ slaves
 
 [mesos:vars]
 mesos_zk_group=zookeepers
-mesos_rpm=mesos-0.22.1
+mesos_rpm=mesos-0.28.1
 mesos_interface=ansible_enp0s8
 mesos_work_dir=/var/mesos
 


### PR DESCRIPTION
Upgrades cluster and all examples in frameworks/ to new mesos.

Rewrites all docker examples to be Alpine based to save space.

push all Docker images to Hub to ease install.

Require Vagrant 1.8 for linked clones.
